### PR TITLE
Remove incorrect monitoring_enabled configuration for kubernetes_cluster example

### DIFF
--- a/examples/vpc/kubernetes_cluster/main.tf
+++ b/examples/vpc/kubernetes_cluster/main.tf
@@ -35,7 +35,6 @@ module "kubernetes_cluster" {
   cluster_master_floating_ip = "${var.cluster_master_floating_ip}"
   cluster_docker_volume_size = "${var.cluster_docker_volume_size}"
   cluster_etcd_volume_size   = "${var.cluster_etcd_volume_size}"
-  cluster_monitoring_enabled = "${var.cluster_monitoring_enabled}"
 
   # Kubernetes cluster masters parameters.
   cluster_master_count = "${var.cluster_master_count}"

--- a/modules/vpc/kubernetes_cluster/main.tf
+++ b/modules/vpc/kubernetes_cluster/main.tf
@@ -58,7 +58,6 @@ resource "openstack_containerinfra_clustertemplate_v1" "clustertemplate_1" {
   master_lb_enabled     = "${var.cluster_master_lb_enabled}"
   floating_ip_enabled   = false
   external_network_id   = "${data.openstack_networking_network_v2.external_net.id}"
-  monitoring_enabled    = "${var.cluster_monitoring_enabled}"
 
   labels = {
     kube_tag                         = "${var.cluster_kube_version}"


### PR DESCRIPTION
As descried in [this issue](https://github.com/selectel/terraform-examples/issues/4) `monitoring_enabled` argument prevents successful execution of `terraform plan` and `terraform apply` so I removed it from module and example.