### PR TITLE
Add explicit Selectel provider source location

### DIFF
--- a/examples/mks/cluster_one_nodegroup/versions.tf
+++ b/examples/mks/cluster_one_nodegroup/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    selectel = {
+      source = "selectel/selectel"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/examples/vpc/server_local_and_remote_disks/versions.tf
+++ b/examples/vpc/server_local_and_remote_disks/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    selectel = {
+      source = "selectel/selectel"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/examples/vpc/server_local_root_disk/versions.tf
+++ b/examples/vpc/server_local_root_disk/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    selectel = {
+      source = "selectel/selectel"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/examples/vpc/server_remote_root_disk/versions.tf
+++ b/examples/vpc/server_remote_root_disk/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    selectel = {
+      source = "selectel/selectel"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/examples/vpc/server_remote_root_disk_two_ports/versions.tf
+++ b/examples/vpc/server_remote_root_disk_two_ports/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    selectel = {
+      source = "selectel/selectel"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/examples/vpc/server_windows/versions.tf
+++ b/examples/vpc/server_windows/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    selectel = {
+      source = "selectel/selectel"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/examples/vpc/several_servers_loadbalancer/versions.tf
+++ b/examples/vpc/several_servers_loadbalancer/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    selectel = {
+      source = "selectel/selectel"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/examples/vpc/several_servers_one_network/versions.tf
+++ b/examples/vpc/several_servers_one_network/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    selectel = {
+      source = "selectel/selectel"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/mks/cluster/versions.tf
+++ b/modules/mks/cluster/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    selectel = {
+      source = "selectel/selectel"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/mks/nodegroup/versions.tf
+++ b/modules/mks/nodegroup/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    selectel = {
+      source = "selectel/selectel"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/vpc/account_token/versions.tf
+++ b/modules/vpc/account_token/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    selectel = {
+      source = "selectel/selectel"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/vpc/image_datasource/versions.tf
+++ b/modules/vpc/image_datasource/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    selectel = {
+      source = "selectel/selectel"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/vpc/keypair/versions.tf
+++ b/modules/vpc/keypair/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    selectel = {
+      source = "selectel/selectel"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/vpc/lb_listener_http/versions.tf
+++ b/modules/vpc/lb_listener_http/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    selectel = {
+      source = "selectel/selectel"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/vpc/lb_listener_udp/versions.tf
+++ b/modules/vpc/lb_listener_udp/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    selectel = {
+      source = "selectel/selectel"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/vpc/lb_loadbalancer/versions.tf
+++ b/modules/vpc/lb_loadbalancer/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    selectel = {
+      source = "selectel/selectel"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/vpc/license/versions.tf
+++ b/modules/vpc/license/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    selectel = {
+      source = "selectel/selectel"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/vpc/project/versions.tf
+++ b/modules/vpc/project/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    selectel = {
+      source = "selectel/selectel"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/vpc/project_token/versions.tf
+++ b/modules/vpc/project_token/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    selectel = {
+      source = "selectel/selectel"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/vpc/project_with_user/versions.tf
+++ b/modules/vpc/project_with_user/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    selectel = {
+      source = "selectel/selectel"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/vpc/role/versions.tf
+++ b/modules/vpc/role/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    selectel = {
+      source = "selectel/selectel"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/vpc/subnet/versions.tf
+++ b/modules/vpc/subnet/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    selectel = {
+      source = "selectel/selectel"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/vpc/user/versions.tf
+++ b/modules/vpc/user/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    selectel = {
+      source = "selectel/selectel"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/vpc/vrrp_subnet/versions.tf
+++ b/modules/vpc/vrrp_subnet/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    selectel = {
+      source = "selectel/selectel"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
Run "terraform 0.13upgrade" command and specify the explicit location of
the Selectel provider,

Provider in Registry:
https://registry.terraform.io/providers/selectel/selectel/latest.

Reference: https://www.terraform.io/upgrade-guides/0-13.html.