### PR TITLE
Remove auto_quotas in resource project_1

### DIFF
--- a/modules/vpc/project/main.tf
+++ b/modules/vpc/project/main.tf
@@ -1,4 +1,3 @@
 resource "selectel_vpc_project_v2" "project_1" {
   name        = var.project_name
-  auto_quotas = true
 }


### PR DESCRIPTION
Removed auto_quotas in resource "selectel_vpc_project_v2" after remove this feature from Selectel Cloud API.