### PR TITLE
feat(vpc): server with direct public ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ services.
 │       ├── server_remote_root_disk_with_custom_iops
 │       ├── server_remote_root_disk_with_server_group
 │       ├── server_windows
+│       ├── server_with_direct_public_ip
+│       ├── server_with_direct_public_ip_separate_attach
 │       ├── several_servers_and_loadbalancers
 │       ├── several_servers_one_network
 │       ├── several_servers_routing

--- a/examples/cloud/server_with_direct_public_ip/README.md
+++ b/examples/cloud/server_with_direct_public_ip/README.md
@@ -1,0 +1,32 @@
+# Server with direct public IP port
+
+This environment creates a Selectel Cloud project with a single server that has a direct public IP via `selectel_vpc_public_port_v1` resource.
+
+Unlike the floating IP approach (which uses a private port + floating IP association), the public port provides a direct public IP address on the port itself.
+
+## What is created
+
+- Selectel project with service user and keypair
+- Security group with SSH (port 22) and ICMP access rules
+- Direct public IP port (`selectel_vpc_public_port_v1`) with the security group attached
+- Compute instance attached to the public port
+
+## Example usage
+
+```sh
+terraform init
+
+env \
+  TF_VAR_username=USER \
+  TF_VAR_password=PASSWORD \
+  TF_VAR_domain_name=ACCOUNT_ID \
+  TF_VAR_user_password=xxx \
+  terraform apply -target=module.project_with_user
+
+env \
+  TF_VAR_username=USER \
+  TF_VAR_password=PASSWORD \
+  TF_VAR_domain_name=ACCOUNT_ID \
+  TF_VAR_user_password=xxx \
+  terraform apply
+```

--- a/examples/cloud/server_with_direct_public_ip/main.tf
+++ b/examples/cloud/server_with_direct_public_ip/main.tf
@@ -97,9 +97,11 @@ resource "openstack_compute_instance_v2" "instance_1" {
   availability_zone = var.server_zone
 
   network {
+    # `uuid` and `name` are both required. `name` is intentionally a dummy
+    # value to avoid an extra network lookup performed by Nova.
     port = selectel_vpc_public_port_v1.public_port_1.id
     uuid = selectel_vpc_public_port_v1.public_port_1.network_id
-    name = "random-net-name-to-avoid-nova-lookup"
+    name = "dummy-network-name"
   }
 
   lifecycle {

--- a/examples/cloud/server_with_direct_public_ip/main.tf
+++ b/examples/cloud/server_with_direct_public_ip/main.tf
@@ -1,0 +1,116 @@
+provider "selectel" {
+  username    = var.username
+  password    = var.password
+  domain_name = var.domain_name
+  auth_region = var.region
+  auth_url    = var.auth_url
+}
+
+module "project_with_user" {
+  providers = {
+    selectel = selectel,
+  }
+  source = "../../../modules/cloud/project_with_user"
+
+  project_name      = var.project_name
+  project_user_name = var.project_user_name
+  user_password     = var.user_password
+}
+
+provider "openstack" {
+  user_name           = var.project_user_name
+  tenant_name         = var.project_name
+  password            = var.user_password
+  project_domain_name = var.domain_name
+  user_domain_name    = var.domain_name
+  auth_url            = var.auth_url
+  region              = var.region
+}
+
+resource "openstack_networking_secgroup_v2" "secgroup_1" {
+  name        = "tf_public_port_sg"
+  description = "Security group for public port"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "ssh_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.secgroup_1.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "icmp_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "icmp"
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.secgroup_1.id
+}
+
+resource "selectel_vpc_public_port_v1" "public_port_1" {
+  region       = var.region
+  project_id   = module.project_with_user.project_id
+  description  = "Public port for ${var.server_name}"
+
+  security_group_ids = [
+    openstack_networking_secgroup_v2.secgroup_1.id,
+  ]
+
+  depends_on = [
+    module.project_with_user,
+  ]
+}
+
+resource "random_string" "random_name" {
+  length  = 5
+  special = false
+}
+
+module "flavor" {
+  source               = "../../../modules/cloud/flavor"
+  flavor_name          = "flavor-${random_string.random_name.result}"
+  flavor_vcpus         = var.server_vcpus
+  flavor_ram_mb        = var.server_ram_mb
+  flavor_local_disk_gb = var.server_root_disk_gb
+}
+
+module "image_datasource" {
+  source     = "../../../modules/cloud/image_datasource"
+  image_name = var.server_image_name
+}
+
+module "keypair" {
+  source             = "../../../modules/cloud/keypair"
+  keypair_name       = "keypair-${random_string.random_name.result}"
+  keypair_public_key = file(pathexpand(var.keypair_path))
+  keypair_user_id    = module.project_with_user.user_id
+}
+
+resource "openstack_compute_instance_v2" "instance_1" {
+  name              = var.server_name
+  image_id          = module.image_datasource.image_id
+  flavor_id         = module.flavor.flavor_id
+  key_pair          = module.keypair.keypair_name
+  availability_zone = var.server_zone
+
+  network {
+    port = selectel_vpc_public_port_v1.public_port_1.id
+    uuid = selectel_vpc_public_port_v1.public_port_1.network_id
+    name = "random-net-name-to-avoid-nova-lookup"
+  }
+
+  lifecycle {
+    ignore_changes = [image_id, availability_zone]
+  }
+
+  vendor_options {
+    ignore_resize_confirmation = true
+  }
+
+  depends_on = [
+    module.project_with_user,
+  ]
+}

--- a/examples/cloud/server_with_direct_public_ip/output.tf
+++ b/examples/cloud/server_with_direct_public_ip/output.tf
@@ -1,0 +1,11 @@
+output "server_id" {
+  value = openstack_compute_instance_v2.instance_1.id
+}
+
+output "public_ip" {
+  value = selectel_vpc_public_port_v1.public_port_1.ip_address
+}
+
+output "security_group_id" {
+  value = openstack_networking_secgroup_v2.secgroup_1.id
+}

--- a/examples/cloud/server_with_direct_public_ip/vars.tf
+++ b/examples/cloud/server_with_direct_public_ip/vars.tf
@@ -1,0 +1,51 @@
+variable "username" {}
+
+variable "password" {}
+
+variable "domain_name" {}
+
+variable "project_name" {
+  default = "tf_project"
+}
+
+variable "project_user_name" {
+  default = "tf_user"
+}
+
+variable "user_password" {}
+
+variable "auth_url" {
+  default = "https://cloud.api.selcloud.ru/identity/v3"
+}
+
+variable "region" {
+  default = "ru-6"
+}
+
+variable "keypair_path" {
+  default = "~/.ssh/id_ed25519.pub"
+}
+
+variable "server_name" {
+  default = "tf_server"
+}
+
+variable "server_zone" {
+  default = "ru-6a"
+}
+
+variable "server_vcpus" {
+  default = 1
+}
+
+variable "server_ram_mb" {
+  default = 4096
+}
+
+variable "server_root_disk_gb" {
+  default = 8
+}
+
+variable "server_image_name" {
+  default = "Ubuntu 22.04 LTS 64-bit"
+}

--- a/examples/cloud/server_with_direct_public_ip/versions.tf
+++ b/examples/cloud/server_with_direct_public_ip/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    selectel = {
+      source  = "selectel/selectel"
+      version = ">= 5.1.1"
+    }
+    openstack = {
+      source  = "terraform-provider-openstack/openstack"
+      version = ">= 2.0.0"
+    }
+  }
+  required_version = ">= 1.9.2"
+}

--- a/examples/cloud/server_with_direct_public_ip_separate_attach/README.md
+++ b/examples/cloud/server_with_direct_public_ip_separate_attach/README.md
@@ -1,0 +1,32 @@
+# Server with direct public IP port
+
+This environment creates a Selectel Cloud project with a single server that has a direct public IP via `selectel_vpc_public_port_v1` resource.
+
+Unlike the floating IP approach (which uses a private port + floating IP association), the public port provides a direct public IP address on the port itself.
+
+## What is created
+
+- Selectel project with service user and keypair
+- Security group with SSH (port 22) and ICMP access rules
+- Direct public IP port (`selectel_vpc_public_port_v1`) with the security group attached
+- Compute instance separately attached to the public port
+
+## Example usage
+
+```sh
+terraform init
+
+env \
+  TF_VAR_username=USER \
+  TF_VAR_password=PASSWORD \
+  TF_VAR_domain_name=ACCOUNT_ID \
+  TF_VAR_user_password=xxx \
+  terraform apply -target=module.project_with_user
+
+env \
+  TF_VAR_username=USER \
+  TF_VAR_password=PASSWORD \
+  TF_VAR_domain_name=ACCOUNT_ID \
+  TF_VAR_user_password=xxx \
+  terraform apply
+```

--- a/examples/cloud/server_with_direct_public_ip_separate_attach/README.md
+++ b/examples/cloud/server_with_direct_public_ip_separate_attach/README.md
@@ -9,7 +9,8 @@ Unlike the floating IP approach (which uses a private port + floating IP associa
 - Selectel project with service user and keypair
 - Security group with SSH (port 22) and ICMP access rules
 - Direct public IP port (`selectel_vpc_public_port_v1`) with the security group attached
-- Compute instance separately attached to the public port
+- Compute instance
+- Compute interface resource (to separately attach a direct public IP port)
 
 ## Example usage
 

--- a/examples/cloud/server_with_direct_public_ip_separate_attach/main.tf
+++ b/examples/cloud/server_with_direct_public_ip_separate_attach/main.tf
@@ -1,0 +1,115 @@
+provider "selectel" {
+  username    = var.username
+  password    = var.password
+  domain_name = var.domain_name
+  auth_region = var.region
+  auth_url    = var.auth_url
+}
+
+module "project_with_user" {
+  providers = {
+    selectel = selectel,
+  }
+  source = "../../../modules/cloud/project_with_user"
+
+  project_name      = var.project_name
+  project_user_name = var.project_user_name
+  user_password     = var.user_password
+}
+
+provider "openstack" {
+  user_name           = var.project_user_name
+  tenant_name         = var.project_name
+  password            = var.user_password
+  project_domain_name = var.domain_name
+  user_domain_name    = var.domain_name
+  auth_url            = var.auth_url
+  region              = var.region
+}
+
+resource "openstack_networking_secgroup_v2" "secgroup_1" {
+  name        = "tf_public_port_sg"
+  description = "Security group for public port"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "ssh_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.secgroup_1.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "icmp_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "icmp"
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.secgroup_1.id
+}
+
+resource "selectel_vpc_public_port_v1" "public_port_1" {
+  region       = var.region
+  project_id   = module.project_with_user.project_id
+  description  = "Public port for ${var.server_name}"
+
+  security_group_ids = [
+    openstack_networking_secgroup_v2.secgroup_1.id,
+  ]
+
+  depends_on = [
+    module.project_with_user,
+  ]
+}
+
+resource "random_string" "random_name" {
+  length  = 5
+  special = false
+}
+
+module "flavor" {
+  source               = "../../../modules/cloud/flavor"
+  flavor_name          = "flavor-${random_string.random_name.result}"
+  flavor_vcpus         = var.server_vcpus
+  flavor_ram_mb        = var.server_ram_mb
+  flavor_local_disk_gb = var.server_root_disk_gb
+}
+
+module "image_datasource" {
+  source     = "../../../modules/cloud/image_datasource"
+  image_name = var.server_image_name
+}
+
+module "keypair" {
+  source             = "../../../modules/cloud/keypair"
+  keypair_name       = "keypair-${random_string.random_name.result}"
+  keypair_public_key = file(pathexpand(var.keypair_path))
+  keypair_user_id    = module.project_with_user.user_id
+}
+
+resource "openstack_compute_instance_v2" "instance_1" {
+  name              = var.server_name
+  image_id          = module.image_datasource.image_id
+  flavor_id         = module.flavor.flavor_id
+  key_pair          = module.keypair.keypair_name
+  availability_zone = var.server_zone
+
+  lifecycle {
+    ignore_changes = [image_id, availability_zone]
+  }
+
+  vendor_options {
+    ignore_resize_confirmation = true
+  }
+
+  depends_on = [
+    module.project_with_user,
+  ]
+}
+
+resource "openstack_compute_interface_attach_v2" "attach" {
+  instance_id = openstack_compute_instance_v2.instance_1.id
+  port_id     = selectel_vpc_public_port_v1.public_port_1.id
+}

--- a/examples/cloud/server_with_direct_public_ip_separate_attach/output.tf
+++ b/examples/cloud/server_with_direct_public_ip_separate_attach/output.tf
@@ -1,0 +1,11 @@
+output "server_id" {
+  value = openstack_compute_instance_v2.instance_1.id
+}
+
+output "public_ip" {
+  value = selectel_vpc_public_port_v1.public_port_1.ip_address
+}
+
+output "security_group_id" {
+  value = openstack_networking_secgroup_v2.secgroup_1.id
+}

--- a/examples/cloud/server_with_direct_public_ip_separate_attach/vars.tf
+++ b/examples/cloud/server_with_direct_public_ip_separate_attach/vars.tf
@@ -1,0 +1,55 @@
+variable "username" {}
+
+variable "password" {
+  sensitive = true
+}
+
+variable "domain_name" {}
+
+variable "project_name" {
+  default = "tf_project"
+}
+
+variable "project_user_name" {
+  default = "tf_user"
+}
+
+variable "user_password" {
+  sensitive = true
+}
+
+variable "auth_url" {
+  default = "https://cloud.api.selcloud.ru/identity/v3"
+}
+
+variable "region" {
+  default = "ru-6"
+}
+
+variable "keypair_path" {
+  default = "~/.ssh/id_ed25519.pub"
+}
+
+variable "server_name" {
+  default = "tf_server"
+}
+
+variable "server_zone" {
+  default = "ru-6a"
+}
+
+variable "server_vcpus" {
+  default = 1
+}
+
+variable "server_ram_mb" {
+  default = 4096
+}
+
+variable "server_root_disk_gb" {
+  default = 8
+}
+
+variable "server_image_name" {
+  default = "Ubuntu 22.04 LTS 64-bit"
+}

--- a/examples/cloud/server_with_direct_public_ip_separate_attach/versions.tf
+++ b/examples/cloud/server_with_direct_public_ip_separate_attach/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    selectel = {
+      source  = "selectel/selectel"
+      version = ">= 5.1.1"
+    }
+    openstack = {
+      source  = "terraform-provider-openstack/openstack"
+      version = ">= 2.0.0"
+    }
+  }
+  required_version = ">= 1.9.2"
+}


### PR DESCRIPTION
Add Terraform examples for servers with direct public IPs.

Changes:

- Add example for creating a server with a direct public IP
- Demonstrate usage of `selectel_vpc_public_port_v1`